### PR TITLE
Add parallax effect to header area and background image

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -106,7 +106,7 @@ button {
   height: 100vh;
 }
 
-.parallax-background-image > div{
+.parallax-background-image > .image-receiver{
   min-height: 500px;
   min-width: 100%;
   position: relative;

--- a/css/custom.css
+++ b/css/custom.css
@@ -112,7 +112,7 @@ button {
   position: relative;
   aspect-ratio: calc(5472 / 2682);
   background-image: url("/img/banner-bg.jpg");
-  background-size: contain;
+  background-size: cover;
   background-position: center;
 }
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -85,6 +85,7 @@ button {
   overflow-x: hidden;
   overflow-y: auto;
 }
+
 .parallax-layer {
   position: absolute;
   top: 0;
@@ -105,7 +106,13 @@ button {
   height: 100vh;
 }
 
-.parallax > #banner{
+.parallax-background-image img{
+  min-height: 500px;
+  width: 100%;
+  aspect-ratio: initial;
+}
+
+#banner{
   transform: translateZ(-0.3px) scale(1.3);
   transform-origin: bottom;
   background-color: transparent;

--- a/css/custom.css
+++ b/css/custom.css
@@ -111,7 +111,7 @@ button {
   min-width: 100%;
   position: relative;
   aspect-ratio: calc(5472 / 2682);
-  background-image: url("/img/banner-bg.jpg");
+  background-image: url("../img/banner-bg.jpg");
   background-size: cover;
   background-position: center;
 }

--- a/css/custom.css
+++ b/css/custom.css
@@ -106,10 +106,14 @@ button {
   height: 100vh;
 }
 
-.parallax-background-image img{
+.parallax-background-image > div{
   min-height: 500px;
-  width: 100%;
-  aspect-ratio: initial;
+  min-width: 100%;
+  position: relative;
+  aspect-ratio: calc(5472 / 2682);
+  background-image: url("/img/banner-bg.jpg");
+  background-size: contain;
+  background-position: center;
 }
 
 #banner{

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,4 +1,7 @@
 /********** Common **********/
+body{
+  overflow:hidden;
+}
 h2 {
   font-size: 2.8rem !important;
   font-weight: 700;
@@ -73,6 +76,39 @@ button {
   background: rgba(255, 255, 255, 0.1);
   border-color: white;
   box-shadow: 0 1px 5px rgba(0, 0, 0, 0.2);
+}
+
+/***** Parallax effect *****/
+.parallax {
+  perspective: 1px;
+  height: 100vh;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.parallax-layer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.parallax-content-layer {
+  transform: translateZ(0);
+  background:white;
+  transform-style: preserve-3d;
+}
+
+.parallax-background-image {
+  transform: translateZ(-1.5px) scale(3);
+  transform-origin: center;
+  height: 100vh;
+}
+
+.parallax > #banner{
+  transform: translateZ(-0.3px) scale(1.3);
+  transform-origin: bottom;
+  background-color: transparent;
 }
 
 /********** Banner **********/

--- a/index.html
+++ b/index.html
@@ -28,121 +28,137 @@
     <link rel="stylesheet" href="css/custom.css" />
   </head>
 
-  <body>
-    <!-- Banner -->
-    <div class="jumbotron jumbotron-fluid" id="banner" style="background-image: url(img/banner-bg.jpg)">
-      <div class="container text-center text-md-center">
-        <header>
-          <div class="row justify-content-between">
-            <div class="col-2">
-              <a href="index.html">
-		<img src="img/logo.png" alt="logo" />
-              </a>
+  <body style="overflow: hidden;">
+    <div class="parallax">
+      <!-- Parallaxing background image -->
+      <div class="parallax-layer parallax-background-image">
+        <img src="img/banner-bg.jpg" aria-hidden="true" />
+      </div>
+
+      <!-- Parallaxing header-->
+      <div class="jumbotron jumbotron-fluid" id="banner">
+        <div class="container text-center text-md-center">
+          <header>
+            <div class="row justify-content-between">
+              <div class="col-2">
+                <a href="index.html">
+                  <img src="img/logo.png" alt="logo" />
+                </a>
+              </div>
+            </div>
+            <h1 data-aos="fade" data-aos-easing="linear" data-aos-duration="1000" class="display-3 text-white font-weight-bold my-2">Files</h1>
+            <h4 data-aos="fade" data-aos-easing="linear" data-aos-duration="1000" class="text-white my-4">
+              A modern file explorer that pushes the boundaries of the platform.
+            </h4>
+            <a
+              href="https://www.microsoft.com/store/apps/9NGHP3DX8HDX"
+              data-aos="fade"
+              data-aos-easing="linear"
+              data-aos-duration="1000"
+              class="btn my-2 mx-2 font-weight-bold cta cta-white"
+              target="_blank"
+            >
+              Download Now
+            </a>
+            <a
+              href="https://github.com/files-community/Files"
+              data-aos="fade"
+              data-aos-easing="linear"
+              data-aos-duration="1000"
+              class="btn my-2 mx-2 font-weight-bold cta cta-white-outline"
+              target="_blank"
+            >
+              View on GitHub
+            </a>
+          </header>
+        </div>
+      </div>
+
+      <!-- Rest of the website -->
+      <div class="parallax-content-layer">
+        <!-- Features -->
+        <div class="container my-5 py-2">
+          <h2 class="text-center font-weight-bold my-5">Notable Features</h2>
+          <div class="row">
+            <div data-aos="fade-up" data-aos-delay="0" data-aos-duration="1000" class="col-md-4 text-center">
+              <img src="img/icons/tabs.svg" alt="Tabs Icon" class="mx-auto my-5" width="110" height="110" />
+              <h4>Multiple Tabs</h4>
+              <p>Multiple tabs to increase your productivity</p>
+            </div>
+            <div data-aos="fade-up" data-aos-delay="200" data-aos-duration="1000" class="col-md-4 text-center">
+              <img
+                src="https://img.icons8.com/fluent/96/000000/paint-palette.png"
+                alt="Fluent Design"
+                class="mx-auto my-5"
+                width="110"
+                height="110"
+              />
+              <h4>Fluent Design</h4>
+              <p>The best of Fluent to enhance usability</p>
+            </div>
+            <div data-aos="fade-up" data-aos-delay="400" data-aos-duration="1000" class="col-md-4 text-center">
+              <img src="img/icons/quicklook.png" alt="QuickLook Icon" class="mx-auto my-5" width="110" height="110" />
+              <h4>QuickLook Support</h4>
+              <p>Full support for QuickLook to quickly preview your files</p>
             </div>
           </div>
-          <h1 data-aos="fade" data-aos-easing="linear" data-aos-duration="1000" class="display-3 text-white font-weight-bold my-2">Files</h1>
-          <h4 data-aos="fade" data-aos-easing="linear" data-aos-duration="1000" class="text-white my-4">
-            A modern file explorer that pushes the boundaries of the platform.
-          </h4>
-          <a
-            href="https://www.microsoft.com/store/apps/9NGHP3DX8HDX"
-            data-aos="fade"
-            data-aos-easing="linear"
-            data-aos-duration="1000"
-            class="btn my-2 mx-2 font-weight-bold cta cta-white"
-            target="_blank"
-          >
-            Download Now
-          </a>
-          <a
-            href="https://github.com/files-community/Files"
-            data-aos="fade"
-            data-aos-easing="linear"
-            data-aos-duration="1000"
-            class="btn my-2 mx-2 font-weight-bold cta cta-white-outline"
-            target="_blank"
-          >
-            View on GitHub
-          </a>
-        </header>
-      </div>
-    </div>
+        </div>
 
-    <!-- Features -->
-    <div class="container my-5 py-2">
-      <h2 class="text-center font-weight-bold my-5">Notable Features</h2>
-      <div class="row">
-        <div data-aos="fade-up" data-aos-delay="0" data-aos-duration="1000" class="col-md-4 text-center">
-          <img src="img/icons/tabs.svg" alt="Tabs Icon" class="mx-auto my-5" width="110" height="110" />
-          <h4>Multiple Tabs</h4>
-          <p>Multiple tabs to increase your productivity</p>
-        </div>
-        <div data-aos="fade-up" data-aos-delay="200" data-aos-duration="1000" class="col-md-4 text-center">
-          <img src="https://img.icons8.com/fluent/96/000000/paint-palette.png" alt="Fluent Design" class="mx-auto my-5" width="110" height="110" />
-          <h4>Fluent Design</h4>
-          <p>The best of Fluent to enhance usability</p>
-        </div>
-        <div data-aos="fade-up" data-aos-delay="400" data-aos-duration="1000" class="col-md-4 text-center">
-          <img src="img/icons/quicklook.png" alt="QuickLook Icon" class="mx-auto my-5" width="110" height="110" />
-          <h4>QuickLook Support</h4>
-          <p>Full support for QuickLook to quickly preview your files</p>
-        </div>
-      </div>
-    </div>
-
-    <!-- Information -->
-    <div class="jumbotron jumbotron-fluid info" id="info">
-      <div class="container my-5">
-        <div class="row justify-content-between text-center text-md-left">
-          <div data-aos="fade-right" data-aos-duration="1000" class="col-md-6">
-            <h2 class="font-weight-bold">Take a look inside</h2>
-            <p class="my-4">Check out the documentation to find tips &amp; tricks and to learn more about Files</p>
-            <a href="https://files-community.github.io/docs/#/" class="btn my-4 cta cta-darkblue" target="_blank">Documentation</a>
-          </div>
-          <div data-aos="fade-left" data-aos-duration="1000" class="col-md-6 align-self-center">
-            <img src="img/laptop-splash.png" alt="Laptop Demo" class="mx-auto d-block" />
+        <!-- Information -->
+        <div class="jumbotron jumbotron-fluid info" id="info">
+          <div class="container my-5">
+            <div class="row justify-content-between text-center text-md-left">
+              <div data-aos="fade-right" data-aos-duration="1000" class="col-md-6">
+                <h2 class="font-weight-bold">Take a look inside</h2>
+                <p class="my-4">Check out the documentation to find tips &amp; tricks and to learn more about Files</p>
+                <a href="https://files-community.github.io/docs/#/" class="btn my-4 cta cta-darkblue" target="_blank">Documentation</a>
+              </div>
+              <div data-aos="fade-left" data-aos-duration="1000" class="col-md-6 align-self-center">
+                <img src="img/laptop-splash.png" alt="Laptop Demo" class="mx-auto d-block" />
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
 
-    <!-- Copyright -->
-    <div class="jumbotron jumbotron-fluid" id="copyright">
-      <div class="container">
-        <div class="row justify-content-between">
-          <div class="col-md-6 text-white align-self-center text-center text-md-left my-2">Copyright © 2021 Files Community</div>
-          <div class="col-md-6 align-self-center text-center text-md-right my-2" id="social-media">
-            <a href="https://github.com/files-community" class="d-inline-block text-center ml-2">
-              <i class="fab fa-github" aria-hidden="true"></i>
-            </a>
-            <a href="https://discord.gg/mr5hVu8" class="d-inline-block text-center ml-2">
-              <i class="fab fa-discord" aria-hidden="true"></i>
-            </a>
+        <!-- Copyright -->
+        <div class="jumbotron jumbotron-fluid" id="copyright">
+          <div class="container">
+            <div class="row justify-content-between">
+              <div class="col-md-6 text-white align-self-center text-center text-md-left my-2">Copyright © 2021 Files Community</div>
+              <div class="col-md-6 align-self-center text-center text-md-right my-2" id="social-media">
+                <a href="https://github.com/files-community" class="d-inline-block text-center ml-2">
+                  <i class="fab fa-github" aria-hidden="true"></i>
+                </a>
+                <a href="https://discord.gg/mr5hVu8" class="d-inline-block text-center ml-2">
+                  <i class="fab fa-discord" aria-hidden="true"></i>
+                </a>
+              </div>
+            </div>
           </div>
         </div>
+
+        <!-- AOS -->
+        <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+        <script>
+          AOS.init();
+        </script>
+
+        <!-- Analytics -->
+        <script type="text/javascript">
+          (function (c, l, a, r, i, t, y) {
+            c[a] =
+              c[a] ||
+              function () {
+                (c[a].q = c[a].q || []).push(arguments);
+              };
+            t = l.createElement(r);
+            t.async = 1;
+            t.src = "https://www.clarity.ms/tag/" + i;
+            y = l.getElementsByTagName(r)[0];
+            y.parentNode.insertBefore(t, y);
+          })(window, document, "clarity", "script", "4q1wajdktz");
+        </script>
       </div>
     </div>
-
-    <!-- AOS -->
-    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
-    <script>
-      AOS.init();
-    </script>
-
-    <!-- Analytics -->
-    <script type="text/javascript">
-      (function (c, l, a, r, i, t, y) {
-        c[a] =
-          c[a] ||
-          function () {
-            (c[a].q = c[a].q || []).push(arguments);
-          };
-        t = l.createElement(r);
-        t.async = 1;
-        t.src = "https://www.clarity.ms/tag/" + i;
-        y = l.getElementsByTagName(r)[0];
-        y.parentNode.insertBefore(t, y);
-      })(window, document, "clarity", "script", "4q1wajdktz");
-    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <div class="parallax">
       <!-- Parallaxing background image -->
       <div class="parallax-layer parallax-background-image">
-        <img src="img/banner-bg.jpg" aria-hidden="true" />
+        <div ></div>
       </div>
 
       <!-- Parallaxing header-->

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="css/custom.css" />
   </head>
 
-  <body style="overflow: hidden;">
+  <body >
     <div class="parallax">
       <!-- Parallaxing background image -->
       <div class="parallax-layer parallax-background-image">
@@ -141,6 +141,13 @@
         <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
         <script>
           AOS.init();
+
+          // AOS does not let us specify the control element
+          // Lets do that ourselfes by refreshing on scroll.
+          document.getElementsByClassName("parallax")[0].addEventListener("scroll", () => {
+            AOS.refresh();
+          })
+
         </script>
 
         <!-- Analytics -->

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <div class="parallax">
       <!-- Parallaxing background image -->
       <div class="parallax-layer parallax-background-image">
-        <div ></div>
+        <div class="image-receiver"></div>
       </div>
 
       <!-- Parallaxing header-->


### PR DESCRIPTION
This PR adds parallaxing to the header area and the underlying background image. Due to a critical assumption in AOS, we need to refresh AOS manually. Below is a GIF showing the effect:
![GIF showing updated parallax effect on files website. Header and background image are being parallaxed](https://user-images.githubusercontent.com/16122379/104506301-7e505e00-55e5-11eb-8f11-d94c7788995e.gif)

Tested on:
Microsoft Edge Dev 89.0.760.0
Chrome 87.0.4280.141
Firefox 84.0.1 

Closes #12 