### PR TITLE
Add repository readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# [files-community.github.io](https://files-community.github.io/)
+
+This repository contains the website of [Files](https://www.microsoft.com/store/apps/9NGHP3DX8HDX), a modern file explorer that pushes the boundaries of the platform.
+You can find the source code of [here](https://github.com/files-community/files-uwp).
+To improve existing documentation or add new documentation, edit the corresponding file in ./docs or add a new file in the `docs` folder.
+The source code of the start page can be found at the root (index.html).
+
+Have ideas or found a mistake? Feel free to file an [issue](https://github.com/files-community/files-community.github.io/issues) or create a [PR](https://github.com/files-community/files-community.github.io/pulls)!
+
+
+## About Files
+Files is a file manager which leverages the latest features of the Windows platform including Fluent Design, seamless updates, and APIs which enable the performance and lifecycle behavior that users expect. Whether you want to simplify your experience with your files or try something new, Files is a one-stop solution for exploring your files on the fly.
+
+## Where to get Files 
+- <a href="https://www.microsoft.com/store/apps/9NGHP3DX8HDX">Microsoft Store</a>
+- <a href="https://github.com/files-community/files-uwp/releases">GitHub</a>


### PR DESCRIPTION
GitHub chose to display the readme.md found in /docs which is not accurate when viewing this repository on GitHub. This PR adds a project README.md to fix this.