### PR TITLE
Add more padding to header to improve button overlap with parallax, add shadow to content area

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -21,6 +21,20 @@ button {
   margin-bottom: 0 !important;
 }
 
+@media (min-width: 576px)
+{
+  .jumbotron{
+    padding: 6rem 2rem;
+  }
+}
+
+@media (max-width: 576px)
+{
+  .jumbotron{
+    padding: 0rem 2rem 6rem 2rem;
+  }
+}
+
 .cta {
   border-radius: 22px !important;
   padding: 12px 30px !important;
@@ -98,6 +112,7 @@ button {
   transform: translateZ(0);
   background:white;
   transform-style: preserve-3d;
+  box-shadow: rgb(0 0 0 / 30%) 0px 0px 20px 10px;
 }
 
 .parallax-background-image {
@@ -107,7 +122,7 @@ button {
 }
 
 .parallax-background-image > .image-receiver{
-  min-height: 500px;
+  min-height: 700px;
   min-width: 100%;
   position: relative;
   background-image: url("../img/banner-bg.jpg");


### PR DESCRIPTION
More padding makes it unlikely to have visual overlap, the shadow creates a subtle clue about the visual hierarchy.

![Gif showing updated parallaxing effect with shadow being visible over background image](https://user-images.githubusercontent.com/16122379/107712279-71e52100-6cc9-11eb-8daa-a87d737a7c8f.gif)
