### PR TITLE
Add issue and PR template to repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,11 @@
+---
+name: General issue
+about: File a bug report, a suggestion or a proposal related to the website or documentation
+title: ''
+labels: ''
+assignees: ''
+---
+
+<!-- Please enter a short, clear description of the bug, the suggestion or proposal -->
+<!-- For bugs and proposals related to the app its self, please file an issue on the Files GitHub repository: https://github.com/files-community/Files -->
+# <Your issue Title>

--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -6,6 +6,6 @@ labels: ''
 assignees: ''
 ---
 
-<!-- Please enter a short, clear description of the bug, the suggestion or proposal -->
-<!-- For bugs and proposals related to the app its self, please file an issue on the Files GitHub repository: https://github.com/files-community/Files -->
+<!-- Please enter a short, clear description of the bug, the suggestion or proposal related to the website or documentation. -->
+<!-- For bugs and proposals related to the Files its self, please file an issue on the Files GitHub repository: https://github.com/files-community/Files -->
 # <Your issue Title>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+<!--- Use the syntax "Closes #1234" or "Fixes #5678" so that GitHub will close the issue once the PR is complete. -->
+
+## How Has This Been Tested?
+<!--- Please describe how you tested your changes. -->
+
+## Screenshots (if appropriate):
+<!--- If you are making visual changes to a Control or adding a new Control, please include screenshots showing the result. -->


### PR DESCRIPTION
Recently, there were a few issues that are related to the app, not this repo. Adding an issue template that points out that app related issues should be filed on the respective repo.

This PR also adds a modified copy of the WinUI repo PR template since this is also missing right now.